### PR TITLE
Update errors object - Cloud API v16.0+.

### DIFF
--- a/src/main/java/com/whatsapp/api/domain/webhook/Error.java
+++ b/src/main/java/com/whatsapp/api/domain/webhook/Error.java
@@ -7,9 +7,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public record Error(
 
-        @JsonProperty("code") int code,
+        @JsonProperty("code")
+        int code,
 
-        @JsonProperty("details") String details,
+        @JsonProperty("title")
+        String title,
 
-        @JsonProperty("title") String title) {
+        @JsonProperty("message")
+        String message,
+
+        @JsonProperty("error_data")
+        ErrorData errorData
+) {
 }

--- a/src/main/java/com/whatsapp/api/domain/webhook/ErrorData.java
+++ b/src/main/java/com/whatsapp/api/domain/webhook/ErrorData.java
@@ -1,0 +1,10 @@
+package com.whatsapp.api.domain.webhook;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ErrorData(
+
+	@JsonProperty("details")
+	String details
+) {
+}

--- a/src/main/java/com/whatsapp/api/domain/webhook/Status.java
+++ b/src/main/java/com/whatsapp/api/domain/webhook/Status.java
@@ -3,6 +3,8 @@ package com.whatsapp.api.domain.webhook;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.whatsapp.api.domain.webhook.type.MessageStatus;
 
+import java.util.List;
+
 /**
  * The type Status.
  *
@@ -12,6 +14,7 @@ import com.whatsapp.api.domain.webhook.type.MessageStatus;
  * @param recipientId  The WhatsApp ID of the recipient.
  * @param status       The status of the message. Valid values are: read, delivered, sent, failed, or deleted.
  * @param timestamp    The timestamp of the status message.
+ * @param errors       The errors object in webhooks triggered by v16.0+ request errors now include message and error_data.details properties, and title values have changed for multiple error codes.
  */
 public record Status(
 
@@ -25,6 +28,8 @@ public record Status(
 
         @JsonProperty("status") MessageStatus status,
 
-        @JsonProperty("timestamp") String timestamp) {
+        @JsonProperty("timestamp") String timestamp,
+
+        @JsonProperty("errors") List<Error> errors) {
 
 }

--- a/src/test/java/com/whatsapp/api/domain/webhook/WebHookPayloadTest.java
+++ b/src/test/java/com/whatsapp/api/domain/webhook/WebHookPayloadTest.java
@@ -173,6 +173,11 @@ class WebHookPayloadTest extends TestUtils {
 
         Assertions.assertEquals(MessageType.UNSUPPORTED, obj.entry().get(0).changes().get(0).value().messages().get(0).type());
         Assertions.assertNotNull(obj.entry().get(0).changes().get(0).value().messages().get(0).errors());
+        var erro = obj.entry().get(0).changes().get(0).value().messages().get(0).errors().get(0);
+        Assertions.assertEquals("Message type unknown", erro.message());
+        Assertions.assertEquals(131051, erro.code());
+        Assertions.assertEquals("Message type unknown", erro.title());
+        Assertions.assertEquals("Message type is currently not supported.", erro.errorData().details());
 
 
     }
@@ -375,7 +380,6 @@ class WebHookPayloadTest extends TestUtils {
 
         var obj = WebHook.constructEvent(payload);
 
-
         Assertions.assertEquals(FieldType.PHONE_NUMBER_QUALITY_UPDATE, obj.entry().get(0).changes().get(0).field());
 
 
@@ -387,7 +391,6 @@ class WebHookPayloadTest extends TestUtils {
 
         var obj = WebHook.constructEvent(payload);
 
-
         Assertions.assertEquals(FieldType.ACCOUNT_UPDATE, obj.entry().get(0).changes().get(0).field());
         Assertions.assertNotNull(obj.entry().get(0).changes().get(0).value().banInfo());
     }
@@ -398,7 +401,6 @@ class WebHookPayloadTest extends TestUtils {
 
         var obj = WebHook.constructEvent(payload);
 
-
         Assertions.assertEquals(FieldType.ACCOUNT_REVIEW_UPDATE, obj.entry().get(0).changes().get(0).field());
     }
 
@@ -408,9 +410,26 @@ class WebHookPayloadTest extends TestUtils {
 
         var obj = WebHook.constructEvent(payload);
 
-
         Assertions.assertEquals(FieldType.ACCOUNT_UPDATE, obj.entry().get(0).changes().get(0).field());
         Assertions.assertEquals(RestrictionType.RESTRICTED_ADD_PHONE_NUMBER_ACTION, obj.entry().get(0).changes().get(0).value().restrictionInfo().get(0).restrictionType());
+    }
+
+    @Test
+    void testDeserializationMediaUploadError() throws IOException, URISyntaxException {
+        var payload = fromResource(JSON_FOLDER + "mediaUploadError.json");
+
+        var obj = WebHook.constructEvent(payload);
+
+        Assertions.assertEquals(FieldType.MESSAGES, obj.entry().get(0).changes().get(0).field());
+
+        var statuses = obj.entry().get(0).changes().get(0).value().statuses();
+
+        Assertions.assertNotNull(statuses);
+
+        Assertions.assertEquals(131053, statuses.get(0).errors().get(0).code());
+        Assertions.assertEquals("Media upload error", statuses.get(0).errors().get(0).title());
+        Assertions.assertEquals("Media upload error", statuses.get(0).errors().get(0).message());
+        Assertions.assertEquals("Unsupported Video mime type text/html. Please use one of video/3gpp, video/mp4.", statuses.get(0).errors().get(0).errorData().details());
     }
 }
 

--- a/src/test/resources/deserialization/mediaUploadError.json
+++ b/src/test/resources/deserialization/mediaUploadError.json
@@ -1,0 +1,38 @@
+{
+  "object":"whatsapp_business_account",
+  "entry":[
+    {
+      "id":"880480571844883",
+      "changes":[
+        {
+          "value":{
+            "messaging_product":"whatsapp",
+            "metadata":{
+              "display_phone_number":"43330585569",
+              "phone_number_id":"409552778964973"
+            },
+            "statuses":[
+              {
+                "id":"wamid.HBgNNTUyNzk5NzAUZBQTI3MzRGRDA3MjgzMDkzNhUCABEYEjNCR2OQA=",
+                "status":"failed",
+                "timestamp":"1677783372",
+                "recipient_id":"1111111111111",
+                "errors":[
+                  {
+                    "code":131053,
+                    "title":"Media upload error",
+                    "message":"Media upload error",
+                    "error_data":{
+                      "details":"Unsupported Video mime type text\/html. Please use one of video\/3gpp, video\/mp4."
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "field":"messages"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/deserialization/messageDeleted.json
+++ b/src/test/resources/deserialization/messageDeleted.json
@@ -27,7 +27,11 @@
                 "errors": [
                   {
                     "code": 131051,
-                    "title": "Message type is currently not supported."
+                    "title": "Message type unknown",
+                    "message": "Message type unknown",
+                    "error_data": {
+                      "details": "Message type is currently not supported."
+                    }
                   }
                 ],
                 "type": "unsupported"


### PR DESCRIPTION
- Update errors object:

The errors object in webhooks triggered by v16.0+ request errors now include message and error_data.details properties, and title values have changed for multiple error codes. Now, errors objects have the following structure and data:
```json
[
  {
    "code": <CODE>,
    "title" : "<TITLE>",
    "message": "<MESSAGE>",
    "error_data": {
      "details": "<DETAILS>"
    }
  },
  ...
]
```