### PR TITLE
[fix] no language code in template

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ These can be instantiated through the corresponding factory method of [`Whatsapp
 #### [Sending a message with buttons (template):](https://github.com/Bindambc/whatsapp-business-java-api/blob/main/src/test/java/com/whatsapp/api/examples/SendTemplateButtonMessageExample.java)
 
 ```java
- 	WhatsappApiFactory factory = WhatsappApiFactory.newInstance(TestUtils.TOKEN);
+	WhatsappApiFactory factory = WhatsappApiFactory.newInstance(TestConstants.TOKEN);
 
         WhatsappBusinessCloudApi whatsappBusinessCloudApi = factory.newBusinessCloudApi();
 
@@ -176,7 +176,7 @@ These can be instantiated through the corresponding factory method of [`Whatsapp
                 .setTo(PHONE_NUMBER_1)//
                 .buildTemplateMessage(//
                         new TemplateMessage()//
-                                .setLanguage(new Language(com.whatsapp.api.domain.templates.Language.PT_BR))//
+                                .setLanguage(new Language(LanguageType.PT_BR))//
                                 .setName("schedule_confirmation3")//
                                 .addComponent(//
                                         new Component(ComponentType.BODY)//

--- a/src/main/java/com/whatsapp/api/domain/messages/Language.java
+++ b/src/main/java/com/whatsapp/api/domain/messages/Language.java
@@ -1,28 +1,12 @@
 package com.whatsapp.api.domain.messages;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.whatsapp.api.domain.templates.type.LanguageType;
 
 /**
- * The type Language.
+ * @param code Language code. See {@link LanguageType}
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record Language(LanguageType code) {
-    /**
-     * Instantiates a new Language.
-     *
-     * @param code the code
-     */
-    public Language {
-    }
-
-    /**
-     * Gets code.
-     *
-     * @return the code
-     */
-    @Override
-    public LanguageType code() {
-        return code;
-    }
+public record Language(@JsonProperty("code") LanguageType code) {
 }

--- a/src/test/java/com/whatsapp/api/examples/SendTemplateTextMessageExample.java
+++ b/src/test/java/com/whatsapp/api/examples/SendTemplateTextMessageExample.java
@@ -34,5 +34,7 @@ public class SendTemplateTextMessageExample {
                 );
 
         whatsappBusinessCloudApi.sendMessage(PHONE_NUMBER_ID, message);
+
+
     }
 }

--- a/src/test/java/com/whatsapp/api/impl/WhatsappBusinessCloudApiTest.java
+++ b/src/test/java/com/whatsapp/api/impl/WhatsappBusinessCloudApiTest.java
@@ -5,12 +5,18 @@ import com.whatsapp.api.TestConstants;
 import com.whatsapp.api.WhatsappApiFactory;
 import com.whatsapp.api.domain.media.FileType;
 import com.whatsapp.api.domain.messages.AudioMessage;
+import com.whatsapp.api.domain.messages.Component;
 import com.whatsapp.api.domain.messages.DocumentMessage;
 import com.whatsapp.api.domain.messages.ImageMessage;
+import com.whatsapp.api.domain.messages.Language;
 import com.whatsapp.api.domain.messages.Message.MessageBuilder;
 import com.whatsapp.api.domain.messages.StickerMessage;
+import com.whatsapp.api.domain.messages.TemplateMessage;
 import com.whatsapp.api.domain.messages.TextMessage;
+import com.whatsapp.api.domain.messages.TextParameter;
 import com.whatsapp.api.domain.messages.VideoMessage;
+import com.whatsapp.api.domain.templates.type.ComponentType;
+import com.whatsapp.api.domain.templates.type.LanguageType;
 import com.whatsapp.api.exception.WhatsappApiException;
 import com.whatsapp.api.exception.utils.Formatter;
 import mockwebserver3.MockResponse;
@@ -89,6 +95,41 @@ public class WhatsappBusinessCloudApiTest extends MockServerUtilsTest {
 
         Assertions.assertEquals("wamid.gBGGSFcCNEOPAgkO_KJ55r4w_ww", response.messages().get(0).id());
     }
+
+    @Test
+    void testSendTemplateTextMessage() throws IOException, URISyntaxException, InterruptedException {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody(fromResource("/message.json")));
+
+        WhatsappApiFactory factory = WhatsappApiFactory.newInstance(TestConstants.TOKEN);
+
+        WhatsappBusinessCloudApi whatsappBusinessCloudApi = factory.newBusinessCloudApi();
+
+
+        var templateMessage = new TemplateMessage()//
+                .setLanguage(new Language(LanguageType.PT_BR))//
+                .setName("number_confirmation")//
+                .addComponent(//
+                        new Component(ComponentType.BODY)//
+                                .addParameter(new TextParameter("18754269072")//
+                                ));
+
+        var message = MessageBuilder.builder()//
+                .setTo(TestConstants.PHONE_NUMBER_1)//
+                .buildTemplateMessage(templateMessage);
+
+        whatsappBusinessCloudApi.sendMessage(PHONE_NUMBER_ID, message);
+
+        RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        Assertions.assertEquals("POST", recordedRequest.getMethod());
+        Assertions.assertEquals("/" + API_VERSION + "/" + PHONE_NUMBER_ID + "/messages", recordedRequest.getPath());
+
+        var expectedBody = """
+                {"messaging_product":"whatsapp","recipient_type":"individual","to":"%s","type":"template","template":{"components":[{"type":"BODY","parameters":[{"type":"text","text":"18754269072"}]}],"name":"number_confirmation","language":{"code":"pt_BR"}}}""";
+
+        Assertions.assertEquals(String.format(expectedBody, PHONE_NUMBER_1), recordedRequest.getBody().readUtf8());
+
+    }
+
 
     @Test
     void testSendAudioMessage() throws IOException, URISyntaxException, InterruptedException {


### PR DESCRIPTION
Fix issue when sending template messages. Error that was returned:  `(#100) The parameter template['language']['code'] is required.`