### PR TITLE
The Formatter class has been moved from the `exception.utils` package to the `utils` package

### DIFF
--- a/src/main/java/com/whatsapp/api/WhatsappApiFactory.java
+++ b/src/main/java/com/whatsapp/api/WhatsappApiFactory.java
@@ -12,7 +12,7 @@ public class WhatsappApiFactory {
     /**
      * Whatsapp token
      */
-    String token;
+   final String token;
 
     /**
      * Create a new whatsapp api factory

--- a/src/main/java/com/whatsapp/api/impl/WhatsappBusinessCloudApi.java
+++ b/src/main/java/com/whatsapp/api/impl/WhatsappBusinessCloudApi.java
@@ -98,7 +98,7 @@ public class WhatsappBusinessCloudApi {
      * @throws URISyntaxException the uri syntax exception
      * @see <a href="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media">official documentation</a>
      */
-    public MediaFile downloadMediaFile(String url) throws URISyntaxException {
+    public MediaFile downloadMediaFile(String url)  {
 
         return executeDownloadSync(whatsappBusinessCloudApiService.downloadMediaFile(url));
 

--- a/src/main/java/com/whatsapp/api/utils/Formatter.java
+++ b/src/main/java/com/whatsapp/api/utils/Formatter.java
@@ -1,11 +1,8 @@
-package com.whatsapp.api.exception.utils;
+package com.whatsapp.api.utils;
 
 /**
  * custom text formatter
- *
- * @deprecated use {@link com.whatsapp.api.utils.Formatter} instead
  */
-@Deprecated(forRemoval = true)
 public class Formatter {
 
     /**
@@ -15,6 +12,7 @@ public class Formatter {
      * @return text formatted in italic. Example: <i>"italic text"</i>
      */
     public static String italic(String text) {
+        if (text == null || text.isBlank()) return text;
         String italic = "_";
         return italic + text + italic;
     }
@@ -26,6 +24,7 @@ public class Formatter {
      * @return bold formatted text. Example: <b>"bold text"</b>
      */
     public static String bold(String text) {
+        if (text == null || text.isBlank()) return text;
         String bold = "*";
         return bold + text + bold;
     }
@@ -37,6 +36,7 @@ public class Formatter {
      * @return strikethrough text. Example: <s>"strikethrough text"</s>
      */
     public static String strikethrough(String text) {
+        if (text == null || text.isBlank()) return text;
         String strikethrough = "~";
         return strikethrough + text + strikethrough;
     }
@@ -48,6 +48,7 @@ public class Formatter {
      * @return text formatted as code. Example: <code>"code text"</code>
      */
     public static String code(String text) {
+        if (text == null || text.isBlank()) return text;
         String code = "```";
         return code + text + code;
     }

--- a/src/test/java/com/whatsapp/api/examples/CreateMessageTemplate2Example.java
+++ b/src/test/java/com/whatsapp/api/examples/CreateMessageTemplate2Example.java
@@ -9,8 +9,8 @@ import com.whatsapp.api.domain.templates.MessageTemplate;
 import com.whatsapp.api.domain.templates.type.Category;
 import com.whatsapp.api.domain.templates.type.HeaderFormat;
 import com.whatsapp.api.domain.templates.type.LanguageType;
-import com.whatsapp.api.exception.utils.Formatter;
 import com.whatsapp.api.impl.WhatsappBusinessManagementApi;
+import com.whatsapp.api.utils.Formatter;
 
 import static com.whatsapp.api.TestConstants.TOKEN;
 import static com.whatsapp.api.TestConstants.WABA_ID;

--- a/src/test/java/com/whatsapp/api/examples/CreateMessageTemplate3Example.java
+++ b/src/test/java/com/whatsapp/api/examples/CreateMessageTemplate3Example.java
@@ -11,8 +11,8 @@ import com.whatsapp.api.domain.templates.QuickReplyButton;
 import com.whatsapp.api.domain.templates.type.Category;
 import com.whatsapp.api.domain.templates.type.HeaderFormat;
 import com.whatsapp.api.domain.templates.type.LanguageType;
-import com.whatsapp.api.exception.utils.Formatter;
 import com.whatsapp.api.impl.WhatsappBusinessManagementApi;
+import com.whatsapp.api.utils.Formatter;
 
 import static com.whatsapp.api.TestConstants.TOKEN;
 import static com.whatsapp.api.TestConstants.WABA_ID;

--- a/src/test/java/com/whatsapp/api/examples/DeleteMediaExample.java
+++ b/src/test/java/com/whatsapp/api/examples/DeleteMediaExample.java
@@ -3,14 +3,11 @@ package com.whatsapp.api.examples;
 import com.whatsapp.api.WhatsappApiFactory;
 import com.whatsapp.api.impl.WhatsappBusinessCloudApi;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-
 import static com.whatsapp.api.TestConstants.TOKEN;
 
 public class DeleteMediaExample {
 
-    public static void main(String[] args) throws IOException, URISyntaxException {
+    public static void main(String[] args)  {
         WhatsappApiFactory factory = WhatsappApiFactory.newInstance(TOKEN);
 
         WhatsappBusinessCloudApi whatsappBusinessCloudApi = factory.newBusinessCloudApi();

--- a/src/test/java/com/whatsapp/api/examples/RequestVerificationCodeExample.java
+++ b/src/test/java/com/whatsapp/api/examples/RequestVerificationCodeExample.java
@@ -1,6 +1,5 @@
 package com.whatsapp.api.examples;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.whatsapp.api.WhatsappApiFactory;
 import com.whatsapp.api.domain.phone.RequestCode;
 import com.whatsapp.api.domain.phone.VerifyCode;
@@ -13,7 +12,7 @@ import static com.whatsapp.api.TestConstants.TOKEN;
 
 public class RequestVerificationCodeExample {
 
-    public static void main(String[] args) throws JsonProcessingException {
+    public static void main(String[] args)  {
 
         WhatsappApiFactory factory = WhatsappApiFactory.newInstance(TOKEN);
 

--- a/src/test/java/com/whatsapp/api/examples/RetrieveMediaUrlExample.java
+++ b/src/test/java/com/whatsapp/api/examples/RetrieveMediaUrlExample.java
@@ -3,13 +3,11 @@ package com.whatsapp.api.examples;
 import com.whatsapp.api.WhatsappApiFactory;
 import com.whatsapp.api.impl.WhatsappBusinessCloudApi;
 
-import java.io.IOException;
-
 import static com.whatsapp.api.TestConstants.TOKEN;
 
 public class RetrieveMediaUrlExample {
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args)  {
         WhatsappApiFactory factory = WhatsappApiFactory.newInstance(TOKEN);
 
         WhatsappBusinessCloudApi whatsappBusinessCloudApi = factory.newBusinessCloudApi();

--- a/src/test/java/com/whatsapp/api/examples/SendTextMessageExample.java
+++ b/src/test/java/com/whatsapp/api/examples/SendTextMessageExample.java
@@ -5,8 +5,8 @@ import com.whatsapp.api.WhatsappApiFactory;
 import com.whatsapp.api.domain.messages.Message.MessageBuilder;
 import com.whatsapp.api.domain.messages.TextMessage;
 import com.whatsapp.api.domain.messages.response.MessageResponse;
-import com.whatsapp.api.exception.utils.Formatter;
 import com.whatsapp.api.impl.WhatsappBusinessCloudApi;
+import com.whatsapp.api.utils.Formatter;
 
 import static com.whatsapp.api.TestConstants.PHONE_NUMBER_1;
 import static com.whatsapp.api.TestConstants.PHONE_NUMBER_ID;

--- a/src/test/java/com/whatsapp/api/exception/utils/FormatterTest.java
+++ b/src/test/java/com/whatsapp/api/exception/utils/FormatterTest.java
@@ -1,0 +1,40 @@
+package com.whatsapp.api.exception.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FormatterTest {
+    /**
+     * Method under test: {@link Formatter#italic(String)}
+     */
+    @Test
+    void testItalic() {
+        assertEquals("_Text_", Formatter.italic("Text"));
+    }
+
+    /**
+     * Method under test: {@link Formatter#bold(String)}
+     */
+    @Test
+    void testBold() {
+        assertEquals("*Text*", Formatter.bold("Text"));
+    }
+
+    /**
+     * Method under test: {@link Formatter#strikethrough(String)}
+     */
+    @Test
+    void testStrikethrough() {
+        assertEquals("~Text~", Formatter.strikethrough("Text"));
+    }
+
+    /**
+     * Method under test: {@link Formatter#code(String)}
+     */
+    @Test
+    void testCode() {
+        assertEquals("```Text```", Formatter.code("Text"));
+    }
+}
+

--- a/src/test/java/com/whatsapp/api/impl/WhatsappBusinessCloudApiTest.java
+++ b/src/test/java/com/whatsapp/api/impl/WhatsappBusinessCloudApiTest.java
@@ -18,7 +18,7 @@ import com.whatsapp.api.domain.messages.VideoMessage;
 import com.whatsapp.api.domain.templates.type.ComponentType;
 import com.whatsapp.api.domain.templates.type.LanguageType;
 import com.whatsapp.api.exception.WhatsappApiException;
-import com.whatsapp.api.exception.utils.Formatter;
+import com.whatsapp.api.utils.Formatter;
 import mockwebserver3.MockResponse;
 import mockwebserver3.RecordedRequest;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/com/whatsapp/api/impl/WhatsappBusinessManagementApiTest.java
+++ b/src/test/java/com/whatsapp/api/impl/WhatsappBusinessManagementApiTest.java
@@ -19,7 +19,7 @@ import com.whatsapp.api.domain.templates.type.Category;
 import com.whatsapp.api.domain.templates.type.HeaderFormat;
 import com.whatsapp.api.domain.templates.type.LanguageType;
 import com.whatsapp.api.exception.WhatsappApiException;
-import com.whatsapp.api.exception.utils.Formatter;
+import com.whatsapp.api.utils.Formatter;
 import mockwebserver3.MockResponse;
 import mockwebserver3.RecordedRequest;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/com/whatsapp/api/utils/FormatterTest.java
+++ b/src/test/java/com/whatsapp/api/utils/FormatterTest.java
@@ -1,0 +1,53 @@
+package com.whatsapp.api.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class FormatterTest {
+    /**
+     * Method under test: {@link Formatter#italic(String)}
+     */
+    @Test
+    void testItalic() {
+        assertEquals("_Text_", Formatter.italic("Text"));
+        assertNull(Formatter.italic(null));
+        assertEquals("    ", Formatter.italic("    "));
+        assertEquals("", Formatter.italic(""));
+    }
+
+    /**
+     * Method under test: {@link Formatter#bold(String)}
+     */
+    @Test
+    void testBold() {
+        assertEquals("*Text*", Formatter.bold("Text"));
+        assertNull(Formatter.bold(null));
+        assertEquals("    ", Formatter.bold("    "));
+        assertEquals("", Formatter.bold(""));
+    }
+
+    /**
+     * Method under test: {@link Formatter#strikethrough(String)}
+     */
+    @Test
+    void testStrikethrough() {
+        assertEquals("~Text~", Formatter.strikethrough("Text"));
+        assertNull(Formatter.strikethrough(null));
+        assertEquals("    ", Formatter.strikethrough("    "));
+        assertEquals("", Formatter.strikethrough(""));
+    }
+
+    /**
+     * Method under test: {@link Formatter#code(String)}
+     */
+    @Test
+    void testCode() {
+        assertEquals("```Text```", Formatter.code("Text"));
+        assertNull(Formatter.code(null));
+        assertEquals("    ", Formatter.code("    "));
+        assertEquals("", Formatter.code(""));
+    }
+}
+


### PR DESCRIPTION
The Formatter class has been moved from the `exception.utils` package to the `utils` package. The existing class in `exceptions.utils ` has been deprecated and will be removed in the next version.