### PR TITLE
New Message Template categories have been added according to the WhatsApp Business API v16.0. Categories prior to version v16.0 have been deprecated.

### DIFF
--- a/src/main/java/com/whatsapp/api/domain/templates/response/MessageTemplateIDResponse.java
+++ b/src/main/java/com/whatsapp/api/domain/templates/response/MessageTemplateIDResponse.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * The type Message template id response.
+ * @deprecated use {@link com.whatsapp.api.domain.templates.MessageTemplate} instead
  */
+@Deprecated(forRemoval = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record MessageTemplateIDResponse(@JsonProperty("id") String id) {
 }

--- a/src/main/java/com/whatsapp/api/domain/templates/response/Template.java
+++ b/src/main/java/com/whatsapp/api/domain/templates/response/Template.java
@@ -3,6 +3,7 @@ package com.whatsapp.api.domain.templates.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.whatsapp.api.domain.templates.Component;
+import com.whatsapp.api.domain.templates.type.Category;
 
 import java.util.List;
 
@@ -20,7 +21,7 @@ public record Template(
 
         @JsonProperty("id") String id,
 
-        @JsonProperty("category") String category,
+        @JsonProperty("category") Category category,
 
         @JsonProperty("status") String status) {
 }

--- a/src/main/java/com/whatsapp/api/domain/templates/type/Category.java
+++ b/src/main/java/com/whatsapp/api/domain/templates/type/Category.java
@@ -1,20 +1,98 @@
 package com.whatsapp.api.domain.templates.type;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 /**
  * <b>Required.</b> The type of message template.
- * Values: TRANSACTIONAL, MARKETING, OTP
  */
 public enum Category {
+
+    /**
+     * Authentication category. Valid category value for whatsapp cloud Api v16.0 and later requests
+     */
+    AUTHENTICATION("AUTHENTICATION"),
+
+    /**
+     * Utility category. Valid category value for whatsapp cloud Api v16.0 and later requests
+     */
+    UTILITY("UTILITY"),
+
     /**
      * Transactional category.
+     * Valid category value for whatsapp cloud Api v15.0 and older requests, until May 1, 2023
      */
-    TRANSACTIONAL,
+    @Deprecated() TRANSACTIONAL("TRANSACTIONAL"),
+
     /**
-     * Marketing category.
+     * Marketing category. Valid category value for whatsapp cloud Api v16.0 and older requests
      */
-    MARKETING,
+    MARKETING("MARKETING"),
     /**
+     * Valid category value for whatsapp cloud api v15.0 and older requests, until May 1, 2023.
      * Otp category.
      */
-    OTP
+    @Deprecated() OTP("OTP"),
+
+    /**
+     * Account update category. Valid category value for whatsapp cloud api v15.0 and older requests, until May 1, 2023.
+     */
+    @Deprecated() ACCOUNT_UPDATE("ACCOUNT_UPDATE"),
+    /**
+     * Payment update category. Valid category value for whatsapp cloud api v15.0 and older requests, until May 1, 2023.
+     */
+    @Deprecated() PAYMENT_UPDATE("PAYMENT_UPDATE"),
+    /**
+     * Personal finance update category. Valid category value for whatsapp cloud api v15.0 and older requests, until May 1, 2023.
+     */
+    @Deprecated() PERSONAL_FINANCE_UPDATE("PERSONAL_FINANCE_UPDATE"),
+    /**
+     * Shipping update category. Valid category value for whatsapp cloud api v15.0 and older requests, until May 1, 2023.
+     */
+    @Deprecated() SHIPPING_UPDATE("SHIPPING_UPDATE"),
+    /**
+     * Reservation update category. Valid category value for whatsapp cloud api v15.0 and older requests, until May 1, 2023.
+     */
+    @Deprecated() RESERVATION_UPDATE("RESERVATION_UPDATE"),
+    /**
+     * Issue resolution category. Valid category value for whatsapp cloud api v15.0 and older requests, until May 1, 2023.
+     */
+    @Deprecated() ISSUE_RESOLUTION("ISSUE_RESOLUTION"),
+    /**
+     * Appointment update category. Valid category value for whatsapp cloud api v15.0 and older requests, until May 1, 2023.
+     */
+    @Deprecated() APPOINTMENT_UPDATE("APPOINTMENT_UPDATE"),
+    /**
+     * Transportation update category. Valid category value for whatsapp cloud api v15.0 and older requests, until May 1, 2023.
+     */
+    @Deprecated() TRANSPORTATION_UPDATE("TRANSPORTATION_UPDATE"),
+    /**
+     * Ticket update category. Valid category value for whatsapp cloud api v15.0 and older requests, until May 1, 2023.
+     */
+    @Deprecated() TICKET_UPDATE("TICKET_UPDATE"),
+    /**
+     * Alert update category. Valid category value for whatsapp cloud api v15.0 and older requests, until May 1, 2023.
+     */
+    @Deprecated() ALERT_UPDATE("ALERT_UPDATE"),
+    /**
+     * Auto reply category. Valid category value for whatsapp cloud api v15.0 and older requests, until May 1, 2023.
+     */
+    @Deprecated() AUTO_REPLY("AUTO_REPLY");
+
+
+    private final String value;
+
+
+    Category(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets value.
+     *
+     * @return the value
+     */
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
 }

--- a/src/main/java/com/whatsapp/api/impl/WhatsappBusinessManagementApi.java
+++ b/src/main/java/com/whatsapp/api/impl/WhatsappBusinessManagementApi.java
@@ -6,8 +6,8 @@ import com.whatsapp.api.domain.phone.RequestCode;
 import com.whatsapp.api.domain.phone.VerifyCode;
 import com.whatsapp.api.domain.response.Response;
 import com.whatsapp.api.domain.templates.MessageTemplate;
-import com.whatsapp.api.domain.templates.response.MessageTemplateIDResponse;
 import com.whatsapp.api.domain.templates.response.MessageTemplates;
+import com.whatsapp.api.domain.templates.response.Template;
 import com.whatsapp.api.service.WhatsappBusinessManagementApiService;
 
 import java.util.HashMap;
@@ -39,9 +39,9 @@ public class WhatsappBusinessManagementApi {
      *
      * @param whatsappBusinessAccountId Represents a specific WhatsApp Business Account (WABA). Make the API call to the WABA ID.
      * @param messageTemplate           {@link MessageTemplate} object
-     * @return {@link MessageTemplateIDResponse} template id
+     * @return {@link Template} template
      */
-    public MessageTemplateIDResponse createMessageTemplate(String whatsappBusinessAccountId, MessageTemplate messageTemplate) {
+    public Template createMessageTemplate(String whatsappBusinessAccountId, MessageTemplate messageTemplate) {
 
         return executeSync(whatsappBusinessManagementApiService.createMessageTemplate(whatsappBusinessAccountId, messageTemplate));
     }
@@ -54,7 +54,7 @@ public class WhatsappBusinessManagementApi {
      * @param messageTemplate           the message template
      * @return the message template id response
      */
-    public MessageTemplateIDResponse updateMessageTemplate(String whatsappBusinessAccountId, String messageTemplateId, MessageTemplate messageTemplate) {
+    public Template updateMessageTemplate(String whatsappBusinessAccountId, String messageTemplateId, MessageTemplate messageTemplate) {
 
         return executeSync(whatsappBusinessManagementApiService.updateMessageTemplate(whatsappBusinessAccountId, messageTemplateId, messageTemplate));
     }

--- a/src/main/java/com/whatsapp/api/service/WhatsappBusinessManagementApiService.java
+++ b/src/main/java/com/whatsapp/api/service/WhatsappBusinessManagementApiService.java
@@ -8,6 +8,7 @@ import com.whatsapp.api.domain.response.Response;
 import com.whatsapp.api.domain.templates.MessageTemplate;
 import com.whatsapp.api.domain.templates.response.MessageTemplateIDResponse;
 import com.whatsapp.api.domain.templates.response.MessageTemplates;
+import com.whatsapp.api.domain.templates.response.Template;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
@@ -35,7 +36,7 @@ public interface WhatsappBusinessManagementApiService {
      * @return the call
      */
     @POST("/" + API_VERSION + "/{whatsapp-business-account-ID}/message_templates")
-    Call<MessageTemplateIDResponse> createMessageTemplate(@Path("whatsapp-business-account-ID") String whatsappBusinessAccountId, @Body MessageTemplate messageTemplate);
+    Call<Template> createMessageTemplate(@Path("whatsapp-business-account-ID") String whatsappBusinessAccountId, @Body MessageTemplate messageTemplate);
 
     /**
      * Update message template call.
@@ -46,7 +47,7 @@ public interface WhatsappBusinessManagementApiService {
      * @return the call
      */
     @POST("/" + API_VERSION + "/{whatsapp-business-account-ID}/message_templates/{message-template-id}")
-    Call<MessageTemplateIDResponse> updateMessageTemplate(@Path("whatsapp-business-account-ID") String whatsappBusinessAccountId, @Path("message-template-id") String messageTemplateId, @Body MessageTemplate messageTemplate);
+    Call<Template> updateMessageTemplate(@Path("whatsapp-business-account-ID") String whatsappBusinessAccountId, @Path("message-template-id") String messageTemplateId, @Body MessageTemplate messageTemplate);
 
     /**
      * Delete message template call.

--- a/src/test/java/com/whatsapp/api/examples/CreateMessageTemplate1Example.java
+++ b/src/test/java/com/whatsapp/api/examples/CreateMessageTemplate1Example.java
@@ -37,6 +37,8 @@ public class CreateMessageTemplate1Example {
 
         ;
 
-        whatsappBusinessCloudApi.createMessageTemplate(WABA_ID, template);
+    var response =    whatsappBusinessCloudApi.createMessageTemplate(WABA_ID, template);
+     System.out.println(response);
+
     }
 }

--- a/src/test/java/com/whatsapp/api/examples/CreateMessageTemplate2Example.java
+++ b/src/test/java/com/whatsapp/api/examples/CreateMessageTemplate2Example.java
@@ -24,7 +24,7 @@ public class CreateMessageTemplate2Example {
         var template = new MessageTemplate();
 
         template.setName("number_confirmation")//
-                .setCategory(Category.TRANSACTIONAL)//
+                .setCategory(Category.UTILITY)//
                 .setLanguage(LanguageType.PT_BR)//
                 .addComponent(new HeaderComponent()//
                         .setText("Código de confirmação")//

--- a/src/test/java/com/whatsapp/api/examples/CreateMessageTemplate3Example.java
+++ b/src/test/java/com/whatsapp/api/examples/CreateMessageTemplate3Example.java
@@ -27,7 +27,7 @@ public class CreateMessageTemplate3Example {
         var template = new MessageTemplate();
 
         template.setName("schedule_confirmation3")//
-                .setCategory(Category.TRANSACTIONAL)//
+                .setCategory(Category.UTILITY)//
                 .setLanguage(LanguageType.PT_BR)//
                 .addComponent(new HeaderComponent()//
                         .setText("Confirmação de Atendimento")//

--- a/src/test/java/com/whatsapp/api/impl/WhatsappBusinessManagementApiTest.java
+++ b/src/test/java/com/whatsapp/api/impl/WhatsappBusinessManagementApiTest.java
@@ -68,6 +68,8 @@ class WhatsappBusinessManagementApiTest extends MockServerUtilsTest {
         var response = whatsappBusinessCloudApi.createMessageTemplate(WABA_ID, template);
 
         Assertions.assertEquals("952305634123456", response.id());
+        Assertions.assertEquals("REJECTED", response.status());
+        Assertions.assertEquals(Category.TRANSACTIONAL, response.category());
 
     }
 

--- a/src/test/resources/template.json
+++ b/src/test/resources/template.json
@@ -1,3 +1,5 @@
 {
+  "status": "REJECTED",
+  "category": "TRANSACTIONAL",
   "id": "952305634123456"
 }


### PR DESCRIPTION
New Message Template categories have been added according to the WhatsApp Business API v16.0. Categories prior to version v16.0 have been deprecated.

Templates [created or edited](https://developers.facebook.com/docs/whatsapp/business-management-api/message-templates) using v16.0 must now be categorized using one of the following categories; all other categories are no longer supported.

- AUTHENTICATION
- MARKETING
- UTILITY