### PR TITLE
fix: adjust proxy implementation

### DIFF
--- a/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
+++ b/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
@@ -70,6 +70,7 @@ public class WhatsappApiServiceGenerator {
 
         sharedClient = sharedClient.newBuilder()
                 .proxySelector(proxySelector)
+                .proxy(proxySelector.getProxy())
                 .build();
 
         if (username == null || pwd == null) {

--- a/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
+++ b/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
@@ -58,7 +58,7 @@ public class WhatsappApiServiceGenerator {
      * </ul>
      * <p>
      * @param host     the host (Not null)
-     * @param port     the port (Not null)
+     * @param port     the port 
      * @param username the username
      * @param pwd      the pwd
      * @see <a href="https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/proxy-selector/">Proxy Selector</a>
@@ -66,13 +66,14 @@ public class WhatsappApiServiceGenerator {
      */
     public static void setHttpProxy(String host, int port, String username, String pwd) {
         Objects.requireNonNull(host, "Host cannot be null");
-        Objects.requireNonNull(port, "Http Port cannot be null");
         CustomHttpProxySelector proxySelector = new CustomHttpProxySelector(host, port);
 
+        sharedClient = sharedClient.newBuilder()
+                .proxySelector(proxySelector)
+                .build();
+
         if (username == null || pwd == null) {
-            sharedClient = sharedClient.newBuilder()
-                    .proxySelector(proxySelector)
-                    .build();
+            //Without authentication 
             return;
         }
 

--- a/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
+++ b/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
@@ -80,7 +80,7 @@ public class WhatsappApiServiceGenerator {
         CustomProxyAuthenticator proxyAuthenticator = new CustomProxyAuthenticator(username, pwd);
 
         sharedClient = sharedClient.newBuilder()
-                .authenticator(proxyAuthenticator)
+                .proxyAuthenticator(proxyAuthenticator)
                 .build();
     }
 

--- a/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
+++ b/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
@@ -37,8 +37,11 @@ public class WhatsappApiServiceGenerator {
     }
 
     static {
+        sharedClient = createDefaultHttpClient();
+    }
 
-        sharedClient = new OkHttpClient.Builder()//
+    public static OkHttpClient createDefaultHttpClient(){
+        return new OkHttpClient.Builder()//
                 .callTimeout(20, TimeUnit.SECONDS)//
                 .pingInterval(20, TimeUnit.SECONDS)//
                 .build();

--- a/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
+++ b/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
@@ -70,7 +70,6 @@ public class WhatsappApiServiceGenerator {
 
         sharedClient = sharedClient.newBuilder()
                 .proxySelector(proxySelector)
-                .proxy(proxySelector.getProxy())
                 .build();
 
         if (username == null || pwd == null) {

--- a/src/main/java/com/whatsapp/api/utils/proxy/CustomHttpProxySelector.java
+++ b/src/main/java/com/whatsapp/api/utils/proxy/CustomHttpProxySelector.java
@@ -13,6 +13,10 @@ import java.util.List;
 public class CustomHttpProxySelector extends ProxySelector {
     private final Proxy proxy;
 
+    public Proxy getProxy() {
+        return proxy;
+    }
+
     public CustomHttpProxySelector(String host, int port) {
         this.proxy = new Proxy(Type.HTTP, new InetSocketAddress(host, port));
     }
@@ -26,4 +30,6 @@ public class CustomHttpProxySelector extends ProxySelector {
     public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
         // Do something here
     }
+
+    
 }

--- a/src/main/java/com/whatsapp/api/utils/proxy/CustomHttpProxySelector.java
+++ b/src/main/java/com/whatsapp/api/utils/proxy/CustomHttpProxySelector.java
@@ -13,10 +13,6 @@ import java.util.List;
 public class CustomHttpProxySelector extends ProxySelector {
     private final Proxy proxy;
 
-    public Proxy getProxy() {
-        return proxy;
-    }
-
     public CustomHttpProxySelector(String host, int port) {
         this.proxy = new Proxy(Type.HTTP, new InetSocketAddress(host, port));
     }

--- a/src/main/java/com/whatsapp/api/utils/proxy/CustomProxyAuthenticator.java
+++ b/src/main/java/com/whatsapp/api/utils/proxy/CustomProxyAuthenticator.java
@@ -10,16 +10,20 @@ import okhttp3.Route;
 
 public class CustomProxyAuthenticator implements Authenticator {
 
-    private final String credential;
+    private final String CREDENTIALS;
+
+    public String getCREDENTIALS() {
+        return CREDENTIALS;
+    }
 
     public CustomProxyAuthenticator(final String username, final String password) {
-        credential = Credentials.basic(username, password);
+        CREDENTIALS = Credentials.basic(username, password);
     }
 
     @Override
     public Request authenticate(final Route route, final Response response) throws IOException {
         return response.request().newBuilder()
-                .header("Proxy-Authorization", credential)
+                .header("Proxy-Authorization", CREDENTIALS)
                 .build();
     }
 }

--- a/src/main/java/com/whatsapp/api/utils/proxy/CustomProxyAuthenticator.java
+++ b/src/main/java/com/whatsapp/api/utils/proxy/CustomProxyAuthenticator.java
@@ -12,10 +12,6 @@ public class CustomProxyAuthenticator implements Authenticator {
 
     private final String CREDENTIALS;
 
-    public String getCREDENTIALS() {
-        return CREDENTIALS;
-    }
-
     public CustomProxyAuthenticator(final String username, final String password) {
         CREDENTIALS = Credentials.basic(username, password);
     }

--- a/src/test/java/com/whatsapp/api/WhatsappApiServiceGeneratorTest.java
+++ b/src/test/java/com/whatsapp/api/WhatsappApiServiceGeneratorTest.java
@@ -1,0 +1,119 @@
+package com.whatsapp.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+import java.net.ProxySelector;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.whatsapp.api.domain.errors.WhatsappApiError;
+import com.whatsapp.api.exception.WhatsappApiException;
+import com.whatsapp.api.utils.proxy.CustomHttpProxySelector;
+import com.whatsapp.api.utils.proxy.CustomProxyAuthenticator;
+
+import okhttp3.Authenticator;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.ResponseBody;
+import retrofit2.Response;
+
+public class WhatsappApiServiceGeneratorTest extends TestUtils {
+
+    @BeforeEach
+    void resetProxy() {
+        WhatsappApiServiceGenerator.sharedClient = WhatsappApiServiceGenerator.createDefaultHttpClient();
+    }
+
+    /**
+     * Method under test:
+     * {@link WhatsappApiServiceGenerator#getSharedClient}
+     */
+    @Test
+    void testGetSharedClient() {
+
+        assertNotNull(WhatsappApiServiceGenerator.getSharedClient(), "Shared client should not be null");
+        assertEquals(WhatsappApiServiceGenerator.getSharedClient().getClass(), OkHttpClient.class, "Shared client should be OkHttpClient");
+
+    }
+
+    /**
+     * Method under test:
+     * {@link WhatsappApiServiceGenerator#getWhatsappApiError}
+     * 
+     * @throws IOException
+     * @throws URISyntaxException
+     * @throws WhatsappApiException
+     */
+    @Test
+    void testGetWhatsappApiError() throws IOException, URISyntaxException {
+
+        String verifyCodeErrorBody = fromResource("/phone/verifyCodeError.json");
+
+        Response<?> response = Response.error(400, ResponseBody.create(verifyCodeErrorBody, MediaType.parse("application/json")));
+        WhatsappApiError apiError = WhatsappApiServiceGenerator.getWhatsappApiError(response);
+
+        assertEquals(136025, apiError.error().code(), "Error code should be 136025");
+        assertEquals(2388093, apiError.error().errorSubcode(), "Error code should be 136025");
+        assertEquals(false, apiError.error().isTransient(), "Error code should be 136025");
+        assertEquals("O c\u00F3digo inserido est\u00E1 incorreto.", apiError.error().errorUserMsg(), "Error code should be 136025");
+        assertEquals("N\u00E3o foi poss\u00EDvel verificar o c\u00F3digo", apiError.error().errorUserSubtitle(), "Error code should be 136025");
+
+    }
+
+    /**
+     * Method under test:
+     * {@link WhatsappApiServiceGenerator#setHttpProxy(String, int, String, String)}
+     */
+    @Test
+    void testSetHttpProxy_WithoutAuthentication() {
+
+        // Pre-condition Proxy
+        assertNull(WhatsappApiServiceGenerator.getSharedClient().proxy(), "Proxy should be null");
+        assertEquals(ProxySelector.getDefault(), WhatsappApiServiceGenerator.getSharedClient().proxySelector(),
+                "Proxy selector should be null");
+
+        // Set proxy in shared client
+        WhatsappApiServiceGenerator.setHttpProxy("localhost", 8080, null, null);
+
+        // Check if proxy is set
+        assertNotNull(WhatsappApiServiceGenerator.getSharedClient().proxySelector(), "Proxy selector should not be null");
+        assertEquals(WhatsappApiServiceGenerator.getSharedClient().proxySelector().getClass(), CustomHttpProxySelector.class, "Proxy selector should be CustomHttpProxySelector");
+
+        // Check if authenticator is NONE
+        assertEquals(Authenticator.NONE, WhatsappApiServiceGenerator.getSharedClient().authenticator(), "Authenticator should be NONE");
+    }
+
+    /**
+     * Method under test:
+     * {@link WhatsappApiServiceGenerator#setHttpProxy(String, int, String, String)}
+     */
+    @Test
+    void testSetHttpProxy_WithAuthentication() {
+
+        // Pre-condition Proxy
+        assertNull(WhatsappApiServiceGenerator.getSharedClient().proxy(), "Proxy should be null");
+        assertEquals(ProxySelector.getDefault(), WhatsappApiServiceGenerator.getSharedClient().proxySelector(),
+                "Proxy selector should be ProxySelector.getDefault()");
+
+        // Pre-condition Authenticator
+        assertEquals(Authenticator.NONE, WhatsappApiServiceGenerator.getSharedClient().authenticator(), "Authenticator should be NONE");
+        assertEquals(Authenticator.NONE, WhatsappApiServiceGenerator.getSharedClient().proxyAuthenticator(), "Authenticator should be NONE");
+
+        // Set proxy with Authentication in shared client
+        WhatsappApiServiceGenerator.setHttpProxy("localhost", 8080, "Proxy-User", "Proxy-Pwd");
+
+        // Check if proxy is set
+        assertNotNull(WhatsappApiServiceGenerator.getSharedClient().proxySelector(), "Proxy selector should not be null");
+        assertEquals(WhatsappApiServiceGenerator.getSharedClient().proxySelector().getClass(), CustomHttpProxySelector.class, "Proxy selector should be CustomHttpProxySelector");
+
+        // Check if authenticator is CustomProxyAuthenticator
+        assertNotNull(WhatsappApiServiceGenerator.getSharedClient().proxyAuthenticator(), "Proxy Authenticator should not be null");
+        assertEquals(CustomProxyAuthenticator.class, WhatsappApiServiceGenerator.getSharedClient().proxyAuthenticator().getClass(), "Authenticator should be CustomProxyAuthenticator");
+
+    }
+}


### PR DESCRIPTION
- Removed `Objects.requireNonNull(port, "Http Port cannot be null"); ` because port is a primitive value
- Move the following snippet of code before of authentication required check
 ```java
sharedClient = sharedClient.newBuilder()
                .proxySelector(proxySelector)
                .build();
```