### PR TITLE
fixed failing of - message_response: "accepted" unknown field sending template_message. ignoring any newer fields

### DIFF
--- a/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
+++ b/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
@@ -9,6 +9,9 @@ import com.whatsapp.api.interceptor.AuthenticationInterceptor;
 import com.whatsapp.api.utils.proxy.CustomProxyAuthenticator;
 import com.whatsapp.api.utils.proxy.CustomHttpProxySelector;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import okhttp3.OkHttpClient;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
@@ -28,7 +31,10 @@ import java.util.concurrent.TimeUnit;
 public class WhatsappApiServiceGenerator {
 
     static OkHttpClient sharedClient;
-    private static final Converter.Factory converterFactory = JacksonConverterFactory.create();
+    private static final Converter.Factory converterFactory = JacksonConverterFactory.create(
+        new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    );
+
     @SuppressWarnings("unchecked")
     private static final Converter<ResponseBody, WhatsappApiError> errorBodyConverter = (Converter<ResponseBody, WhatsappApiError>) converterFactory.responseBodyConverter(WhatsappApiError.class, new Annotation[0], null);
 


### PR DESCRIPTION
Hi,

A new field "message_status" is coming in the response of sending template message. and existing jackson converter is failing on finding newer fields. So i have ignored the feature of failing on unknown fields. Other workaround might be adding new field in MessageResponse.java record class, but again things may break if something comeups up again.

Please review and merge it to your main branch. You have developed really beautiful code. great work.


{
    "messaging_product": "whatsapp",
    "contacts": [
        {
            "input": "918553224979",
            "wa_id": "918553224979"
        }
    ],
    "messages": [
        {
            "id": "wamid.HBgMOTE4NTUzMjI0OTc5FQIAERgSNEIzRDZGNTY2RDBCQkZGQTU1AA==",
            "message_status": "accepted"
        }
    ]
}