### PR TITLE
#153 -> including support for other API versions >= v16.0.

### DIFF
--- a/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
+++ b/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
@@ -1,17 +1,15 @@
 package com.whatsapp.api;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.whatsapp.api.configuration.WhatsappApiConfig;
 import com.whatsapp.api.domain.errors.Error;
 import com.whatsapp.api.domain.errors.WhatsappApiError;
 import com.whatsapp.api.domain.media.MediaFile;
 import com.whatsapp.api.exception.WhatsappApiException;
 import com.whatsapp.api.interceptor.AuthenticationInterceptor;
-import com.whatsapp.api.utils.proxy.CustomProxyAuthenticator;
 import com.whatsapp.api.utils.proxy.CustomHttpProxySelector;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
+import com.whatsapp.api.utils.proxy.CustomProxyAuthenticator;
 import okhttp3.OkHttpClient;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
@@ -32,7 +30,7 @@ public class WhatsappApiServiceGenerator {
 
     static OkHttpClient sharedClient;
     private static final Converter.Factory converterFactory = JacksonConverterFactory.create(
-        new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     );
 
     @SuppressWarnings("unchecked")
@@ -46,7 +44,7 @@ public class WhatsappApiServiceGenerator {
         sharedClient = createDefaultHttpClient();
     }
 
-    public static OkHttpClient createDefaultHttpClient(){
+    public static OkHttpClient createDefaultHttpClient() {
         return new OkHttpClient.Builder()//
                 .callTimeout(20, TimeUnit.SECONDS)//
                 .pingInterval(20, TimeUnit.SECONDS)//
@@ -66,8 +64,9 @@ public class WhatsappApiServiceGenerator {
      * you can pass {@code null} as parameters for {@code username} and {@code pwd}.
      * </ul>
      * <p>
+     *
      * @param host     the host (Not null)
-     * @param port     the port 
+     * @param port     the port
      * @param username the username
      * @param pwd      the pwd
      * @see <a href="https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/proxy-selector/">Proxy Selector</a>
@@ -129,7 +128,7 @@ public class WhatsappApiServiceGenerator {
      */
     public static <S> S createService(Class<S> serviceClass, String token) {
 
-        var baseUrl = WhatsappApiConfig.BASE_DOMAIN;
+        var baseUrl = WhatsappApiConfig.BASE_DOMAIN + WhatsappApiConfig.API_VERSION + "/";
         return createService(serviceClass, token, baseUrl);
 
     }

--- a/src/main/java/com/whatsapp/api/configuration/ApiVersion.java
+++ b/src/main/java/com/whatsapp/api/configuration/ApiVersion.java
@@ -1,0 +1,20 @@
+package com.whatsapp.api.configuration;
+
+public enum ApiVersion {
+
+    @Deprecated()
+    V16_0("v16.0"),
+    V17_0("v17.0"),
+    V18_0("v18.0"),
+    V19_0("v19.0");
+
+    private final String value;
+
+    ApiVersion(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/whatsapp/api/configuration/WhatsappApiConfig.java
+++ b/src/main/java/com/whatsapp/api/configuration/WhatsappApiConfig.java
@@ -5,10 +5,14 @@ package com.whatsapp.api.configuration;
  */
 public class WhatsappApiConfig {
 
+
+    private WhatsappApiConfig() {
+    }
+
     /**
      * The constant API_VERSION.
      */
-    public final static String API_VERSION = "v16.0";
+    public static String API_VERSION = ApiVersion.V19_0.getValue();
     /**
      * The constant BASE_DOMAIN.
      */
@@ -21,6 +25,15 @@ public class WhatsappApiConfig {
      */
     public static void setBaseDomain(String baseDomain) {
         BASE_DOMAIN = baseDomain;
+    }
+
+    /**
+     * Sets api version.
+     *
+     * @param apiVersion the api version enum
+     */
+    public static void setApiVersion(ApiVersion apiVersion) {
+        API_VERSION = apiVersion.getValue();
     }
 
 

--- a/src/main/java/com/whatsapp/api/service/WhatsappBusinessCloudApiService.java
+++ b/src/main/java/com/whatsapp/api/service/WhatsappBusinessCloudApiService.java
@@ -21,8 +21,6 @@ import retrofit2.http.Path;
 import retrofit2.http.Streaming;
 import retrofit2.http.Url;
 
-import static com.whatsapp.api.configuration.WhatsappApiConfig.API_VERSION;
-
 /**
  * The interface Whatsapp business cloud api service.
  */
@@ -35,7 +33,7 @@ public interface WhatsappBusinessCloudApiService {
      * @param message       the message
      * @return the call
      */
-    @POST("/" + API_VERSION + "/{Phone-Number-ID}/messages")
+    @POST("/{Phone-Number-ID}/messages")
     Call<MessageResponse> sendMessage(@Path("Phone-Number-ID") String phoneNumberId, @Body Message message);
 
     /**
@@ -47,7 +45,7 @@ public interface WhatsappBusinessCloudApiService {
      * @return the call
      */
     @Multipart
-    @POST("/" + API_VERSION + "/{Phone-Number-ID}/media")
+    @POST( "/{Phone-Number-ID}/media")
     Call<UploadResponse> uploadMedia(@Path("Phone-Number-ID") String phoneNumberId, @Part MultipartBody.Part file,
                                      @Part MultipartBody.Part messageProduct);
 
@@ -57,7 +55,7 @@ public interface WhatsappBusinessCloudApiService {
      * @param mediaId the media id
      * @return the call
      */
-    @GET("/" + API_VERSION + "/{media-id}")
+    @GET("/{media-id}")
     Call<Media> retrieveMediaUrl(@Path("media-id") String mediaId);
 
     /**
@@ -77,7 +75,7 @@ public interface WhatsappBusinessCloudApiService {
      * @param mediaId the media id
      * @return the call
      */
-    @DELETE("/" + API_VERSION + "/{media-id}")
+    @DELETE("/{media-id}")
     Call<Response> deleteMedia(@Path("media-id") String mediaId);
 
     /**
@@ -87,7 +85,7 @@ public interface WhatsappBusinessCloudApiService {
      * @param message       the message
      * @return the call
      */
-    @POST("/" + API_VERSION + "/{Phone-Number-ID}/messages")
+    @POST("/{Phone-Number-ID}/messages")
     Call<Response> markMessageAsRead(@Path("Phone-Number-ID") String phoneNumberId, @Body ReadMessage message);
 
     /**
@@ -97,7 +95,7 @@ public interface WhatsappBusinessCloudApiService {
      * @param twoStepCode   the two-step code
      * @return the call
      */
-    @POST("/" + API_VERSION + "/{Phone-Number-ID}")
+    @POST("/{Phone-Number-ID}")
     Call<Response> twoStepVerification(@Path("Phone-Number-ID") String phoneNumberId, @Body TwoStepCode twoStepCode);
 
 }

--- a/src/main/java/com/whatsapp/api/service/WhatsappBusinessManagementApiService.java
+++ b/src/main/java/com/whatsapp/api/service/WhatsappBusinessManagementApiService.java
@@ -21,8 +21,6 @@ import retrofit2.http.QueryMap;
 
 import java.util.Map;
 
-import static com.whatsapp.api.configuration.WhatsappApiConfig.API_VERSION;
-
 /**
  * The interface Whatsapp business management api service.
  */
@@ -36,7 +34,7 @@ public interface WhatsappBusinessManagementApiService {
      * @param messageTemplate           the message template
      * @return the call
      */
-    @POST("/" + API_VERSION + "/{whatsapp-business-account-ID}/message_templates")
+    @POST( "/{whatsapp-business-account-ID}/message_templates")
     Call<Template> createMessageTemplate(@Path("whatsapp-business-account-ID") String whatsappBusinessAccountId, @Body MessageTemplate messageTemplate);
 
     /**
@@ -47,7 +45,7 @@ public interface WhatsappBusinessManagementApiService {
      * @param messageTemplate           the message template
      * @return the call
      */
-    @POST("/" + API_VERSION + "/{whatsapp-business-account-ID}/message_templates/{message-template-id}")
+    @POST("/{whatsapp-business-account-ID}/message_templates/{message-template-id}")
     Call<Template> updateMessageTemplate(@Path("whatsapp-business-account-ID") String whatsappBusinessAccountId, @Path("message-template-id") String messageTemplateId, @Body MessageTemplate messageTemplate);
 
     /**
@@ -57,7 +55,7 @@ public interface WhatsappBusinessManagementApiService {
      * @param name                      the name
      * @return the call
      */
-    @DELETE("/" + API_VERSION + "/{whatsapp-business-account-ID}/message_templates")
+    @DELETE("/{whatsapp-business-account-ID}/message_templates")
     Call<Response> deleteMessageTemplate(@Path("whatsapp-business-account-ID") String whatsappBusinessAccountId, @Query("name") String name);
 
     /**
@@ -66,7 +64,7 @@ public interface WhatsappBusinessManagementApiService {
      * @param whatsappBusinessAccountId the whatsapp business account id
      * @return the call
      */
-    @GET("/" + API_VERSION + "/{whatsapp-business-account-ID}/message_templates")
+    @GET("/{whatsapp-business-account-ID}/message_templates")
     Call<MessageTemplates> retrieveTemplates(@Path("whatsapp-business-account-ID") String whatsappBusinessAccountId);
 
     /**
@@ -76,7 +74,7 @@ public interface WhatsappBusinessManagementApiService {
      * @param filters                   the filters
      * @return the call
      */
-    @GET("/" + API_VERSION + "/{whatsapp-business-account-ID}/message_templates")
+    @GET("/{whatsapp-business-account-ID}/message_templates")
     Call<MessageTemplates> retrieveTemplates(@Path("whatsapp-business-account-ID") String whatsappBusinessAccountId, @QueryMap Map<String, Object> filters);
 
 
@@ -87,7 +85,7 @@ public interface WhatsappBusinessManagementApiService {
      * @param queryParams   the query params
      * @return the call
      */
-    @GET("/" + API_VERSION + "/{phone-number-ID}")
+    @GET("/{phone-number-ID}")
     Call<PhoneNumber> retrievePhoneNumber(@Path("phone-number-ID") String phoneNumberId, @QueryMap Map<String, Object> queryParams);
 
 
@@ -97,7 +95,7 @@ public interface WhatsappBusinessManagementApiService {
      * @param whatsappBusinessAccountId the whatsapp business account id
      * @return the call
      */
-    @GET("/" + API_VERSION + "/{whatsapp-business-account-ID}/phone_numbers")
+    @GET("/{whatsapp-business-account-ID}/phone_numbers")
     Call<PhoneNumbers> retrievePhoneNumbers(@Path("whatsapp-business-account-ID") String whatsappBusinessAccountId);
 
     /**
@@ -107,7 +105,7 @@ public interface WhatsappBusinessManagementApiService {
      * @param requestCode   the request code
      * @return the call
      */
-    @POST("/" + API_VERSION + "/{phone-number-ID}/request_code")
+    @POST("/{phone-number-ID}/request_code")
     Call<Response> requestCode(@Path("phone-number-ID") String phoneNumberId, @Body RequestCode requestCode);
 
     /**
@@ -117,7 +115,7 @@ public interface WhatsappBusinessManagementApiService {
      * @param verifyCode    the verify code
      * @return the call
      */
-    @POST("/" + API_VERSION + "/{phone-number-ID}/verify_code")
+    @POST("/{phone-number-ID}/verify_code")
     Call<Response> verifyCode(@Path("phone-number-ID") String phoneNumberId, @Body VerifyCode verifyCode);
 
     /**
@@ -127,7 +125,7 @@ public interface WhatsappBusinessManagementApiService {
      * @param queryParams   the query params
      * @return the call
      */
-    @GET("/" + API_VERSION + "/{phone-number-ID}/whatsapp_commerce_settings")
+    @GET("/{phone-number-ID}/whatsapp_commerce_settings")
     Call<GraphCommerceSettings> getWhatsappCommerceSettings(@Path("phone-number-ID") String phoneNumberId, @QueryMap Map<String, String> queryParams);
 
     /**
@@ -137,6 +135,6 @@ public interface WhatsappBusinessManagementApiService {
      * @param commerceDataItem the query params
      * @return the call
      */
-    @POST("/" + API_VERSION + "/{phone-number-ID}/whatsapp_commerce_settings")
+    @POST("/{phone-number-ID}/whatsapp_commerce_settings")
     Call<Response> updateWhatsappCommerceSettings(@Path("phone-number-ID") String phoneNumberId, @Body CommerceDataItem commerceDataItem);
 }

--- a/src/test/java/com/whatsapp/api/examples/SendTemplateButtonMessageExample.java
+++ b/src/test/java/com/whatsapp/api/examples/SendTemplateButtonMessageExample.java
@@ -2,6 +2,8 @@ package com.whatsapp.api.examples;
 
 import com.whatsapp.api.TestConstants;
 import com.whatsapp.api.WhatsappApiFactory;
+import com.whatsapp.api.configuration.ApiVersion;
+import com.whatsapp.api.configuration.WhatsappApiConfig;
 import com.whatsapp.api.domain.messages.BodyComponent;
 import com.whatsapp.api.domain.messages.ButtonComponent;
 import com.whatsapp.api.domain.messages.ButtonPayloadParameter;
@@ -18,6 +20,8 @@ import static com.whatsapp.api.TestConstants.PHONE_NUMBER_ID;
 
 public class SendTemplateButtonMessageExample {
     public static void main(String[] args) {
+        // setting the api version
+        WhatsappApiConfig.setApiVersion(ApiVersion.V17_0);
         WhatsappApiFactory factory = WhatsappApiFactory.newInstance(TestConstants.TOKEN);
 
         WhatsappBusinessCloudApi whatsappBusinessCloudApi = factory.newBusinessCloudApi();


### PR DESCRIPTION
Now it's possible to change the API version through the WhatsappApiConfig class.
Example: 

```java
        //changing API version before instantiating the API client
        WhatsappApiConfig.setApiVersion(ApiVersion.V17_0);
        WhatsappApiFactory factory = WhatsappApiFactory.newInstance(TestConstants.TOKEN);

        WhatsappBusinessCloudApi whatsappBusinessCloudApi = factory.newBusinessCloudApi();
```

closes #153 