### PR TITLE
Fix endpoint for updating message templates

### DIFF
--- a/src/main/java/com/whatsapp/api/impl/WhatsappBusinessManagementApi.java
+++ b/src/main/java/com/whatsapp/api/impl/WhatsappBusinessManagementApi.java
@@ -67,14 +67,13 @@ public class WhatsappBusinessManagementApi {
     /**
      * Update message template message template id response.
      *
-     * @param whatsappBusinessAccountId the whatsapp business account id
      * @param messageTemplateId         the message template id
      * @param messageTemplate           the message template
      * @return the message template id response
      */
-    public Template updateMessageTemplate(String whatsappBusinessAccountId, String messageTemplateId, MessageTemplate messageTemplate) {
+    public Template updateMessageTemplate(String messageTemplateId, MessageTemplate messageTemplate) {
 
-        return executeSync(whatsappBusinessManagementApiService.updateMessageTemplate(apiVersion.getValue(), whatsappBusinessAccountId, messageTemplateId, messageTemplate));
+        return executeSync(whatsappBusinessManagementApiService.updateMessageTemplate(apiVersion.getValue(), messageTemplateId, messageTemplate));
     }
 
     /**

--- a/src/main/java/com/whatsapp/api/service/WhatsappBusinessManagementApiService.java
+++ b/src/main/java/com/whatsapp/api/service/WhatsappBusinessManagementApiService.java
@@ -34,13 +34,12 @@ public interface WhatsappBusinessManagementApiService {
     /**
      * Update message template call.
      *
-     * @param whatsappBusinessAccountId the whatsapp business account id
      * @param messageTemplateId         the message template id
      * @param messageTemplate           the message template
      * @return the call
      */
-    @POST("/{api-version}/{whatsapp-business-account-ID}/message_templates/{message-template-id}")
-    Call<Template> updateMessageTemplate(@Path("api-version") String apiVersion, @Path("whatsapp-business-account-ID") String whatsappBusinessAccountId, @Path("message-template-id") String messageTemplateId, @Body MessageTemplate messageTemplate);
+    @POST("/{api-version}/{message-template-id}")
+    Call<Template> updateMessageTemplate(@Path("api-version") String apiVersion, @Path("message-template-id") String messageTemplateId, @Body MessageTemplate messageTemplate);
 
     /**
      * Delete message template call.

--- a/src/test/java/com/whatsapp/api/examples/UpdateMessageTemplateExample.java
+++ b/src/test/java/com/whatsapp/api/examples/UpdateMessageTemplateExample.java
@@ -11,7 +11,6 @@ import com.whatsapp.api.domain.templates.type.LanguageType;
 import com.whatsapp.api.impl.WhatsappBusinessManagementApi;
 
 import static com.whatsapp.api.TestConstants.TOKEN;
-import static com.whatsapp.api.TestConstants.WABA_ID;
 
 public class UpdateMessageTemplateExample {
 
@@ -34,7 +33,7 @@ public class UpdateMessageTemplateExample {
                                 .addBodyTextExamples("Mr. José", "satisfaction")//
                         ))//
         ;
-        whatsappBusinessCloudApi.updateMessageTemplate(WABA_ID, "1144996326396573", template);
+        whatsappBusinessCloudApi.updateMessageTemplate("1144996326396573", template);
     }
 
 }

--- a/src/test/java/com/whatsapp/api/impl/WhatsappBusinessManagementApiTest.java
+++ b/src/test/java/com/whatsapp/api/impl/WhatsappBusinessManagementApiTest.java
@@ -398,7 +398,7 @@ class WhatsappBusinessManagementApiTest extends MockServerUtilsTest {
     }
 
     /**
-     * Method under test: {@link WhatsappBusinessManagementApi#updateMessageTemplate(String, String, MessageTemplate)}
+     * Method under test: {@link WhatsappBusinessManagementApi#updateMessageTemplate(String, MessageTemplate)}
      */
     @Test
     void testUpdateMessageTemplate() throws IOException, URISyntaxException
@@ -423,7 +423,7 @@ class WhatsappBusinessManagementApiTest extends MockServerUtilsTest {
                                                                           .addBodyTextExamples("Mr. José", "satisfaction")//
                                                  ));
 
-        var response = whatsappBusinessCloudApi.updateMessageTemplate(WABA_ID, "952305634123456", template);
+        var response = whatsappBusinessCloudApi.updateMessageTemplate("952305634123456", template);
 
         Assertions.assertEquals("952305634123456", response.id());
     }


### PR DESCRIPTION
Hello,

I encountered an error while trying to update a message template and found the root cause.

The library currently uses the endpoint https://graph.facebook.com/API_VERSION/WABA_ID/message_templates/TEMPLATE_ID to update a template. However, according to the documentation, the correct endpoint should be https://graph.facebook.com/API_VERSION/TEMPLATE_ID.

Documentation reference:

[WhatsApp Business Management API - Message Templates](https://developers.facebook.com/docs/whatsapp/business-management-api/message-templates/)

I have made the necessary changes to correct this endpoint. Since this is a small change, I believe it should be straightforward to review.

Greetings.