### PR TITLE
Make call timeout configurable

### DIFF
--- a/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
+++ b/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
@@ -20,6 +20,7 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -96,6 +97,13 @@ public class WhatsappApiServiceGenerator {
                 .build();
     }
 
+    public static void setTimeout(final Duration duration) {
+
+        Objects.requireNonNull(duration, "Duration cannot be null");
+        sharedClient = sharedClient.newBuilder()
+                                   .callTimeout( duration )
+                                   .build();
+    }
 
     /**
      * Create service s.

--- a/src/test/java/com/whatsapp/api/WhatsappApiServiceGeneratorTest.java
+++ b/src/test/java/com/whatsapp/api/WhatsappApiServiceGeneratorTest.java
@@ -15,6 +15,7 @@ import retrofit2.Response;
 import java.io.IOException;
 import java.net.ProxySelector;
 import java.net.URISyntaxException;
+import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -116,4 +117,21 @@ class WhatsappApiServiceGeneratorTest extends TestUtils {
         assertEquals(CustomProxyAuthenticator.class, WhatsappApiServiceGenerator.getSharedClient().proxyAuthenticator().getClass(), "Authenticator should be CustomProxyAuthenticator");
 
     }
+
+    /**
+     * Method under test:
+     * {@link WhatsappApiServiceGenerator#setTimeout(Duration)}
+     */
+    @Test
+    void testSetTimeout() {
+
+        assertEquals( 20 * 1000, WhatsappApiServiceGenerator.getSharedClient().callTimeoutMillis() );
+
+        // Set timeout in shared client
+        WhatsappApiServiceGenerator.setTimeout( Duration.ofMinutes( 1L ) );
+
+        // Check if timeout is set
+        assertEquals( 60 * 1000, WhatsappApiServiceGenerator.getSharedClient().callTimeoutMillis() );
+    }
+
 }


### PR DESCRIPTION
Make the call timeout configurable. We noticed that the default call timeout of 20 seconds would often cause timeouts when uploading media or when creating templates.